### PR TITLE
Disable linker relaxation for riscv64

### DIFF
--- a/tools/lkl/Makefile.autoconf
+++ b/tools/lkl/Makefile.autoconf
@@ -38,6 +38,11 @@ define aarch64_host
   $(call set_autoconf_var,AARCH64,y)
 endef
 
+define riscv64_host
+  $(call set_autoconf_var,RISCV64,y)
+  LDFLAGS += -Wl,--no-relax
+endef
+
 define virtio_net_dpdk
   $(call set_autoconf_var,VIRTIO_NET_DPDK,y)
   RTE_SDK ?= $(OUTPUT)/dpdk-17.02
@@ -75,6 +80,7 @@ define posix_host
   $(if $(filter $(1),elf64-x86-64-freebsd),$(call bsd_host))
   $(if $(filter $(1),elf32-littlearm),$(call arm_host))
   $(if $(filter $(1),elf64-littleaarch64),$(call aarch64_host))
+  $(if $(filter $(1),elf64-littleriscv),$(call riscv64_host))
   $(if $(filter yes,$(dpdk)),$(call virtio_net_dpdk))
   $(if $(filter yes,$(vde)),$(call virtio_net_vde))
   $(if $(strip $(call find_include,fuse3/fuse.h)),$(call set_autoconf_var,FUSE,y))

--- a/tools/lkl/Targets
+++ b/tools/lkl/Targets
@@ -9,6 +9,7 @@ LDFLAGS_lib/hijack/liblkl-hijack-y += -shared -nodefaultlibs
 LDLIBS_lib/hijack/liblkl-hijack-y += -ldl
 LDLIBS_lib/hijack/liblkl-hijack-$(LKL_HOST_CONFIG_ARM) += -lgcc -lc
 LDLIBS_lib/hijack/liblkl-hijack-$(LKL_HOST_CONFIG_AARCH64) += -lgcc -lc
+LDLIBS_lib/hijack/liblkl-hijack-$(LKL_HOST_CONFIG_RISCV64) += -lgcc -lc
 LDLIBS_lib/hijack/liblkl-hijack-$(LKL_HOST_CONFIG_I386) += -lc_nonshared
 
 LDFLAGS_lib/hijack/liblkl-zpoline-$(LKL_HOST_CONFIG_POSIX) += -shared -nodefaultlibs


### PR DESCRIPTION
Previously, a large amount of time was taken during the linker relaxation of riscv64 architecture.

This disables it and reduces the link time to several seconds.

The success compilation process is as follows:
1. Set Output format to `elf64-littleriscv` in menuconfig
2. Use the following command to compile it
```
make CROSS_COMPILE=riscv64-linux-gnu- -C tools/lkl
```
