### PR TITLE
lkl: add lkl_if_set_mac to support set MAC address on the interface

### DIFF
--- a/tools/lkl/include/lkl.h
+++ b/tools/lkl/include/lkl.h
@@ -576,6 +576,15 @@ int lkl_if_down(int ifindex);
 int lkl_if_set_mtu(int ifindex, int mtu);
 
 /**
+ * lkl_if_set_mac - set MAC address on interface
+ *
+ * @ifindex - the ifindex of the interface
+ * @addr - 6-byte MAC address
+ * @returns - return 0 if no error: otherwise negative value returns
+ */
+int lkl_if_set_mac(int ifindex, void *addr);
+
+/**
  * lkl_if_set_ipv4 - set IPv4 address on interface
  *
  * @ifindex - the ifindex of the interface

--- a/tools/lkl/lib/net.c
+++ b/tools/lkl/lib/net.c
@@ -141,6 +141,31 @@ int lkl_if_set_mtu(int ifindex, int mtu)
 	return err;
 }
 
+int lkl_if_set_mac(int ifindex, void *addr)
+{
+	struct lkl_ifreq ifr;
+	int err, sock;
+
+	sock = lkl_sys_socket(LKL_AF_INET, LKL_SOCK_DGRAM, 0);
+	if (sock < 0)
+		return sock;
+
+	err = ifindex_to_name(sock, &ifr, ifindex);
+	if (err < 0)
+		goto out;
+
+	err = lkl_sys_ioctl(sock, LKL_SIOCGIFHWADDR, (long)&ifr);
+	if (!err) {
+		memcpy(ifr.lkl_ifr_hwaddr.sa_data, addr, LKL_ETH_ALEN);
+		err = lkl_sys_ioctl(sock, LKL_SIOCSIFHWADDR, (long)&ifr);
+	}
+
+out:
+	lkl_sys_close(sock);
+
+	return err;
+}
+
 int lkl_if_set_ipv4(int ifindex, unsigned int addr, unsigned int netmask_len)
 {
 	return lkl_if_add_ip(ifindex, LKL_AF_INET, &addr, netmask_len);


### PR DESCRIPTION
Currently, we can only set the MAC address when using `lkl_netdev_add` to add a new network device. Otherwise, it will generate a random one through `eth_hw_addr_random`. 

It would be more flexible to support dynamically MAC address configuration.