### PR TITLE
lkl: pci: Fix freeing DMA allocation with CPU address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
             os: unix
             runs_on: ubuntu-22.04
             shell: bash
-          - displayTargetName: kasan
+          - displayTargetName: kunit
             os: unix
             runs_on: ubuntu-22.04
             shell: bash
-            build_options: "kasan=yes kasan_test=yes"
+            build_options: "kunit=yes"
           - displayTargetName: mmu_kasan
             os: unix
             runs_on: ubuntu-22.04

--- a/arch/lkl/Kconfig
+++ b/arch/lkl/Kconfig
@@ -127,6 +127,18 @@ config PCI
 	select ARCH_HAS_DMA_OPS
 	default y
 
+config LKL_PCI_KUNIT_TEST
+	bool "KUnit tests for LKL PCI DMA"
+	depends on PCI && KUNIT
+	default n
+	help
+	  Enable KUnit tests for the LKL PCI DMA mapping operations.
+
+	  These tests exercise the LKL PCI dma_map_ops allocation and free
+	  paths through stub PCI host operations, and verify that coherent DMA
+	  memory returned to callers is unmapped and released using the correct
+	  CPU address.
+
 config RAID6_PQ_BENCHMARK
 	bool
 	default n

--- a/arch/lkl/drivers/Makefile
+++ b/arch/lkl/drivers/Makefile
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0
 
 obj-$(CONFIG_PCI) += pci.o
+obj-$(CONFIG_LKL_PCI_KUNIT_TEST) += pci_test.o

--- a/arch/lkl/drivers/pci.c
+++ b/arch/lkl/drivers/pci.c
@@ -121,7 +121,7 @@ static void lkl_dma_free(struct device *dev, size_t size, void *cpu_addr,
 			 dma_addr_t dma_addr, unsigned long attrs)
 {
 	lkl_ops->pci_ops->unmap_page(to_pci_dev(dev)->sysdata, dma_addr, size);
-	__free_pages(cpu_addr, get_order(size));
+	__free_pages(virt_to_page(cpu_addr), get_order(size));
 }
 
 static dma_addr_t lkl_dma_map_page(struct device *dev, struct page *page,

--- a/arch/lkl/drivers/pci_test.c
+++ b/arch/lkl/drivers/pci_test.c
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <kunit/test.h>
+
+#include <linux/dma-mapping.h>
+#include <linux/gfp.h>
+#include <linux/mm.h>
+#include <linux/module.h>
+#include <linux/page_ref.h>
+#include <linux/pci.h>
+
+#include <asm/host_ops.h>
+
+#define LKL_DMA_TEST_HANDLE	0x4c4b4cULL
+
+struct lkl_dma_test_state {
+	struct lkl_pci_dev *mapped_dev;
+	void *mapped_vaddr;
+	unsigned long mapped_size;
+	unsigned int map_calls;
+	struct lkl_pci_dev *unmapped_dev;
+	unsigned long long unmapped_handle;
+	unsigned long unmapped_size;
+	unsigned int unmap_calls;
+};
+
+static struct lkl_dma_test_state *lkl_dma_test_state;
+
+static unsigned long long lkl_dma_test_map_page(struct lkl_pci_dev *dev,
+						void *vaddr,
+						unsigned long size)
+{
+	lkl_dma_test_state->mapped_dev = dev;
+	lkl_dma_test_state->mapped_vaddr = vaddr;
+	lkl_dma_test_state->mapped_size = size;
+	lkl_dma_test_state->map_calls++;
+
+	return LKL_DMA_TEST_HANDLE;
+}
+
+static void lkl_dma_test_unmap_page(struct lkl_pci_dev *dev,
+				    unsigned long long dma_handle,
+				    unsigned long size)
+{
+	lkl_dma_test_state->unmapped_dev = dev;
+	lkl_dma_test_state->unmapped_handle = dma_handle;
+	lkl_dma_test_state->unmapped_size = size;
+	lkl_dma_test_state->unmap_calls++;
+}
+
+static struct lkl_dev_pci_ops lkl_dma_test_pci_ops = {
+	.map_page = lkl_dma_test_map_page,
+	.unmap_page = lkl_dma_test_unmap_page,
+};
+
+static void lkl_dma_alloc_free_test(struct kunit *test)
+{
+	struct lkl_dev_pci_ops *saved_pci_ops;
+	struct lkl_dma_test_state state = {};
+	struct pci_dev pdev = {};
+	dma_addr_t dma_handle;
+	struct page *page;
+	void *cpu_addr;
+
+	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, lkl_ops);
+
+	pdev.sysdata = &state;
+	pdev.dma_mask = DMA_BIT_MASK(64);
+	pdev.dev.dma_mask = &pdev.dma_mask;
+	pdev.dev.coherent_dma_mask = DMA_BIT_MASK(64);
+
+	lkl_dma_test_state = &state;
+	saved_pci_ops = lkl_ops->pci_ops;
+	lkl_ops->pci_ops = &lkl_dma_test_pci_ops;
+
+	cpu_addr = dma_alloc_attrs(&pdev.dev, PAGE_SIZE, &dma_handle,
+				   GFP_KERNEL, 0);
+	KUNIT_EXPECT_NOT_ERR_OR_NULL(test, cpu_addr);
+	if (!cpu_addr)
+		goto out_restore;
+
+	page = virt_to_page(cpu_addr);
+	KUNIT_EXPECT_EQ(test, page_count(page), 1);
+	KUNIT_EXPECT_EQ(test, state.map_calls, 1);
+	KUNIT_EXPECT_PTR_EQ(test, state.mapped_dev,
+			    (struct lkl_pci_dev *)pdev.sysdata);
+	KUNIT_EXPECT_PTR_EQ(test, state.mapped_vaddr, cpu_addr);
+	KUNIT_EXPECT_EQ(test, state.mapped_size, PAGE_SIZE);
+	KUNIT_EXPECT_EQ(test, dma_handle, (dma_addr_t)LKL_DMA_TEST_HANDLE);
+
+	dma_free_attrs(&pdev.dev, PAGE_SIZE, cpu_addr, dma_handle, 0);
+
+	KUNIT_EXPECT_EQ(test, page_count(page), 0);
+	KUNIT_EXPECT_EQ(test, state.unmap_calls, 1);
+	KUNIT_EXPECT_PTR_EQ(test, state.unmapped_dev,
+			    (struct lkl_pci_dev *)pdev.sysdata);
+	KUNIT_EXPECT_EQ(test, state.unmapped_handle, LKL_DMA_TEST_HANDLE);
+	KUNIT_EXPECT_EQ(test, state.unmapped_size, PAGE_SIZE);
+
+out_restore:
+	lkl_ops->pci_ops = saved_pci_ops;
+	lkl_dma_test_state = NULL;
+}
+
+static struct kunit_case lkl_pci_kunit_test_cases[] = {
+	KUNIT_CASE(lkl_dma_alloc_free_test),
+	{}
+};
+
+static struct kunit_suite lkl_pci_kunit_test_suite = {
+	.name = "lkl_pci",
+	.test_cases = lkl_pci_kunit_test_cases,
+};
+
+kunit_test_suite(lkl_pci_kunit_test_suite);
+
+MODULE_LICENSE("GPL");

--- a/tools/lkl/Makefile.autoconf
+++ b/tools/lkl/Makefile.autoconf
@@ -118,7 +118,6 @@ endef
 
 define kasan_test_enable
   $(call set_kernel_config,KUNIT,y)
-  $(call set_kernel_config,BUILTIN_CMDLINE,\"kunit.filter_glob=\")
   $(call set_kernel_config,KASAN_KUNIT_TEST,y)
 endef
 
@@ -249,10 +248,12 @@ define mmu_test_enable
   $(call set_kernel_config,LKL_MMU_KUNIT_TEST,y)
 endef
 
-define pci_test_enable
+define kunit_test_enable
   $(call set_autoconf_var,LKL_PCI_KUNIT_TEST,y)
   $(call set_kernel_config,KUNIT,y)
   $(call set_kernel_config,LKL_PCI_KUNIT_TEST,y)
+  $(if $(filter $(LD_FMT),$(KASAN_HOSTS)),$(call set_kernel_config,KASAN,y))
+  $(if $(filter $(LD_FMT),$(KASAN_HOSTS)),$(call kasan_test_enable))
 endef
 
 define do_autoconf_mmu
@@ -268,7 +269,7 @@ define do_autoconf
   $(if $(filter $(EXEC_FMT),$(POSIX_HOSTS)),$(call posix_host,$(LD_FMT)))
   $(if $(filter $(EXEC_FMT),$(NT_HOSTS)),$(call nt_host,$(LD_FMT)))
   $(if $(and $(filter yes,$(kasan)),$(filter $(LD_FMT),$(KASAN_HOSTS))),$(call kasan_enable,$(LD_FMT)))
-  $(if $(PCI_KUNIT), $(call pci_test_enable))
+  $(if $(kunit), $(call kunit_test_enable))
   $(if $(MMU),$(call do_autoconf_mmu))
 endef
 

--- a/tools/lkl/Makefile.autoconf
+++ b/tools/lkl/Makefile.autoconf
@@ -249,6 +249,12 @@ define mmu_test_enable
   $(call set_kernel_config,LKL_MMU_KUNIT_TEST,y)
 endef
 
+define pci_test_enable
+  $(call set_autoconf_var,LKL_PCI_KUNIT_TEST,y)
+  $(call set_kernel_config,KUNIT,y)
+  $(call set_kernel_config,LKL_PCI_KUNIT_TEST,y)
+endef
+
 define do_autoconf_mmu
   $(call set_autoconf_var,MMU,y)
   $(call set_kernel_config,MMU,y)
@@ -262,6 +268,7 @@ define do_autoconf
   $(if $(filter $(EXEC_FMT),$(POSIX_HOSTS)),$(call posix_host,$(LD_FMT)))
   $(if $(filter $(EXEC_FMT),$(NT_HOSTS)),$(call nt_host,$(LD_FMT)))
   $(if $(and $(filter yes,$(kasan)),$(filter $(LD_FMT),$(KASAN_HOSTS))),$(call kasan_enable,$(LD_FMT)))
+  $(if $(PCI_KUNIT), $(call pci_test_enable))
   $(if $(MMU),$(call do_autoconf_mmu))
 endef
 

--- a/tools/lkl/tests/boot.c
+++ b/tools/lkl/tests/boot.c
@@ -690,7 +690,36 @@ static int lkl_test_kunit_mmu(void)
 #define LKL_MMU_TEST_CMD_LINE
 #endif // LKL_HOST_CONFIG_LKL_MMU_TEST
 
-#define CMD_LINE "mem=32M loglevel=8 " KASAN_CMD_LINE LKL_MMU_TEST_CMD_LINE
+#ifdef LKL_HOST_CONFIG_LKL_PCI_KUNIT_TEST
+static int lkl_test_kunit_pci(void)
+{
+	char *log = strdup(boot_log);
+	char *line = NULL;
+	int n;
+
+	line = strtok(log, "\n");
+	while (line) {
+		if (sscanf(line, "[ %*f] ok %d lkl_pci", &n) == 1) {
+			lkl_test_logf("%s", line);
+			free(log);
+			return TEST_SUCCESS;
+		}
+
+		line = strtok(NULL, "\n");
+	}
+
+	free(log);
+
+	return TEST_FAILURE;
+}
+
+#define LKL_PCI_TEST_CMD_LINE "kunit.filter_glob=lkl_pci "
+#else
+#define LKL_PCI_TEST_CMD_LINE
+#endif // LKL_HOST_CONFIG_LKL_PCI_KUNIT_TEST
+
+#define CMD_LINE "mem=32M loglevel=8 " KASAN_CMD_LINE LKL_MMU_TEST_CMD_LINE \
+	LKL_PCI_TEST_CMD_LINE
 
 static int lkl_test_start_kernel(void)
 {
@@ -759,6 +788,9 @@ struct lkl_test tests[] = {
 #endif
 #ifdef LKL_HOST_CONFIG_LKL_MMU_TEST
 	LKL_TEST(kunit_mmu),
+#endif
+#ifdef LKL_HOST_CONFIG_LKL_PCI_KUNIT_TEST
+	LKL_TEST(kunit_pci),
 #endif
 	LKL_TEST(stop_kernel),
 };

--- a/tools/lkl/tests/boot.c
+++ b/tools/lkl/tests/boot.c
@@ -557,8 +557,6 @@ static const char *boot_log;
 
 #ifdef LKL_CONFIG_KASAN_KUNIT_TEST
 
-#define KASAN_CMD_LINE
-
 static int lkl_test_kasan(void)
 {
 	char *log = strdup(boot_log);
@@ -584,8 +582,6 @@ out:
 	free(log);
 	return result;
 }
-#else
-#define KASAN_CMD_LINE
 #endif
 
 #ifdef LKL_HOST_CONFIG_MMU
@@ -684,10 +680,6 @@ static int lkl_test_kunit_mmu(void)
 
 	return TEST_FAILURE;
 }
-
-#define LKL_MMU_TEST_CMD_LINE
-#else
-#define LKL_MMU_TEST_CMD_LINE
 #endif // LKL_HOST_CONFIG_LKL_MMU_TEST
 
 #ifdef LKL_HOST_CONFIG_LKL_PCI_KUNIT_TEST
@@ -712,14 +704,9 @@ static int lkl_test_kunit_pci(void)
 
 	return TEST_FAILURE;
 }
-
-#define LKL_PCI_TEST_CMD_LINE
-#else
-#define LKL_PCI_TEST_CMD_LINE
 #endif // LKL_HOST_CONFIG_LKL_PCI_KUNIT_TEST
 
-#define CMD_LINE "mem=32M loglevel=8 " KASAN_CMD_LINE LKL_MMU_TEST_CMD_LINE \
-	LKL_PCI_TEST_CMD_LINE
+#define CMD_LINE "mem=32M loglevel=8 "
 
 static int lkl_test_start_kernel(void)
 {

--- a/tools/lkl/tests/boot.c
+++ b/tools/lkl/tests/boot.c
@@ -557,7 +557,7 @@ static const char *boot_log;
 
 #ifdef LKL_CONFIG_KASAN_KUNIT_TEST
 
-#define KASAN_CMD_LINE "kunit.filter_glob=kasan* "
+#define KASAN_CMD_LINE
 
 static int lkl_test_kasan(void)
 {
@@ -685,7 +685,7 @@ static int lkl_test_kunit_mmu(void)
 	return TEST_FAILURE;
 }
 
-#define LKL_MMU_TEST_CMD_LINE "kunit.filter_glob=lkl_mmu "
+#define LKL_MMU_TEST_CMD_LINE
 #else
 #define LKL_MMU_TEST_CMD_LINE
 #endif // LKL_HOST_CONFIG_LKL_MMU_TEST
@@ -713,7 +713,7 @@ static int lkl_test_kunit_pci(void)
 	return TEST_FAILURE;
 }
 
-#define LKL_PCI_TEST_CMD_LINE "kunit.filter_glob=lkl_pci "
+#define LKL_PCI_TEST_CMD_LINE
 #else
 #define LKL_PCI_TEST_CMD_LINE
 #endif // LKL_HOST_CONFIG_LKL_PCI_KUNIT_TEST


### PR DESCRIPTION
lkl_dma_alloc() returns a kernel virtual address derived from the allocated page. The DMA ops free callback receives that same CPU address, but lkl_dma_free() passed it directly to __free_pages(), which expects a struct page pointer.

Convert the CPU address with virt_to_page() before freeing it.

Add an LKL PCI KUnit test that exercises dma_alloc_attrs() and dma_free_attrs() through stub PCI host ops, and wire it into the LKL test configuration via PCI_KUNIT.