### PR TITLE
lkl: per-thread irqs_enabled fixes IRQ-leak hangs under real drivers

### DIFF
--- a/arch/lkl/Kconfig
+++ b/arch/lkl/Kconfig
@@ -139,6 +139,19 @@ config LKL_PCI_KUNIT_TEST
 	  memory returned to callers is unmapped and released using the correct
 	  CPU address.
 
+config LKL_IRQ_KUNIT_TEST
+	bool "KUnit tests for LKL IRQ host-thread caller path"
+	depends on KUNIT
+	default n
+	help
+	  Enable KUnit tests for arch/lkl/kernel/irq.c.
+
+	  Exercises the contract documented on lkl_trigger_irq that it
+	  is callable from arbitrary host threads. A KUnit test spawns
+	  a real host pthread via lkl_ops->thread_create and asserts
+	  that the registered handler runs synchronously when the host
+	  thread calls lkl_trigger_irq from outside any kernel context.
+
 config RAID6_PQ_BENCHMARK
 	bool
 	default n

--- a/arch/lkl/include/asm/thread_info.h
+++ b/arch/lkl/include/asm/thread_info.h
@@ -18,6 +18,18 @@ struct thread_info {
 	lkl_thread_t tid;
 	struct task_struct *prev_sched;
 	unsigned long stackend;
+	/*
+	 * IRQ-enable state, accessed via current_thread_info() from
+	 * arch_local_save_flags / arch_local_irq_restore in
+	 * arch/lkl/kernel/irq.c. Living here (instead of as a single
+	 * global) means __switch_to moves the state with the thread
+	 * for free: the line
+	 *
+	 *   _current_thread_info = task_thread_info(next);
+	 *
+	 * in arch/lkl/kernel/threads.c is the whole save/restore.
+	 */
+	unsigned long irqs_enabled;
 };
 
 #define INIT_THREAD_INFO(tsk)				\
@@ -25,6 +37,7 @@ struct thread_info {
 	.task		= &tsk,				\
 	.preempt_count	= INIT_PREEMPT_COUNT,		\
 	.flags		= 0,				\
+	.irqs_enabled	= 1, /* ARCH_IRQ_ENABLED */	\
 }
 
 /* how to get the thread information struct from C */

--- a/arch/lkl/kernel/Makefile
+++ b/arch/lkl/kernel/Makefile
@@ -6,3 +6,5 @@ KASAN_SANITIZE_stacktrace.o := n
 
 obj-y = setup.o threads.o irq.o time.o syscalls.o misc.o console.o \
 	syscalls_32.o cpu.o init.o stacktrace.o
+
+obj-$(CONFIG_LKL_IRQ_KUNIT_TEST) += irq_test.o

--- a/arch/lkl/kernel/irq.c
+++ b/arch/lkl/kernel/irq.c
@@ -95,12 +95,31 @@ int lkl_trigger_irq(int irq)
 	/*
 	 * Since this can be called from Linux context (e.g. lkl_trigger_irq ->
 	 * IRQ -> softirq -> lkl_trigger_irq) make sure we are actually allowed
-	 * to run irqs at this point
+	 * to run irqs at this point.
+	 *
+	 * The per-thread irqs_enabled check only applies when the caller
+	 * actually OWNS current_thread_info — i.e. it is the kernel
+	 * thread (or host_task) whose context lkl_cpu_get most recently
+	 * switched to. Calls from a true host pthread (a libusb
+	 * completion thread, a glibc SIGEV_THREAD timer callback, etc.)
+	 * acquire the LKL CPU but never set _current_thread_info; it
+	 * still points at whichever kernel task last ran, often the idle
+	 * task. Honoring that stale flag for host callers silently pends
+	 * the IRQ (real drivers driven through host-pthread backends
+	 * trip this reliably). Detect host callers by comparing
+	 * thread_self() to the thread_info owner's tid and deliver
+	 * unconditionally in that case.
 	 */
-	if (!current_thread_info()->irqs_enabled) {
-		set_irq_pending(irq);
-		lkl_cpu_put();
-		return 0;
+	{
+		struct thread_info *ti = current_thread_info();
+		bool caller_is_kernel = lkl_ops->thread_equal(ti->tid,
+						lkl_ops->thread_self());
+
+		if (caller_is_kernel && !ti->irqs_enabled) {
+			set_irq_pending(irq);
+			lkl_cpu_put();
+			return 0;
+		}
 	}
 
 	run_irq(irq);

--- a/arch/lkl/kernel/irq.c
+++ b/arch/lkl/kernel/irq.c
@@ -52,7 +52,13 @@ static struct irq_info {
 	const char *user;
 } irqs[NR_IRQS];
 
-static bool irqs_enabled;
+/*
+ * irqs_enabled lives in struct thread_info; see
+ * arch/lkl/include/asm/thread_info.h. Accessed via current_thread_info()
+ * in arch_local_save_flags / arch_local_irq_restore below. Switching
+ * _current_thread_info in __switch_to (arch/lkl/kernel/threads.c) is
+ * the entire save/restore: no explicit per-thread save/load is needed.
+ */
 
 static struct pt_regs dummy;
 
@@ -91,7 +97,7 @@ int lkl_trigger_irq(int irq)
 	 * IRQ -> softirq -> lkl_trigger_irq) make sure we are actually allowed
 	 * to run irqs at this point
 	 */
-	if (!irqs_enabled) {
+	if (!current_thread_info()->irqs_enabled) {
 		set_irq_pending(irq);
 		lkl_cpu_put();
 		return 0;
@@ -168,15 +174,17 @@ void lkl_put_irq(int i, const char *user)
 
 unsigned long arch_local_save_flags(void)
 {
-	return irqs_enabled;
+	return current_thread_info()->irqs_enabled;
 }
 
 void arch_local_irq_restore(unsigned long flags)
 {
-	if (flags == ARCH_IRQ_ENABLED && irqs_enabled == ARCH_IRQ_DISABLED &&
+	struct thread_info *ti = current_thread_info();
+
+	if (flags == ARCH_IRQ_ENABLED && ti->irqs_enabled == ARCH_IRQ_DISABLED &&
 	    !in_interrupt())
 		run_irqs();
-	irqs_enabled = flags;
+	ti->irqs_enabled = flags;
 }
 
 void init_IRQ(void)

--- a/arch/lkl/kernel/irq_test.c
+++ b/arch/lkl/kernel/irq_test.c
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <kunit/test.h>
+
+#include <linux/atomic.h>
+#include <linux/completion.h>
+#include <linux/interrupt.h>
+#include <linux/jiffies.h>
+#include <linux/module.h>
+
+#include <asm/host_ops.h>
+#include <asm/irq.h>
+
+/*
+ * KUnit coverage for the host-pthread caller path of lkl_trigger_irq.
+ *
+ * lkl_trigger_irq is documented as callable "from arbitrary host
+ * threads" — backends like a libusb event thread post URB completions
+ * by injecting an IRQ into the LKL kernel from outside any kernel
+ * context. A host pthread doesn't own current_thread_info() (it never
+ * went through __switch_to), so any per-thread state read from there
+ * belongs to whichever kernel task most recently switched in.
+ *
+ * This test spawns a real host pthread via lkl_ops->thread_create,
+ * has it call lkl_trigger_irq on a kernel-registered IRQ from outside
+ * any kernel context, and asserts the handler runs synchronously —
+ * the contract that host-thread-driven backends rely on.
+ */
+
+static struct completion handler_fired;
+static atomic_t handler_runs;
+static int test_irq;
+
+static irqreturn_t test_irq_handler(int irq, void *data)
+{
+	atomic_inc(&handler_runs);
+	complete(&handler_fired);
+	return IRQ_HANDLED;
+}
+
+static void host_thread_trigger(void *arg)
+{
+	lkl_trigger_irq(*(int *)arg);
+}
+
+static void host_thread_irq_delivery_test(struct kunit *test)
+{
+	lkl_thread_t tid;
+	long ret;
+
+	atomic_set(&handler_runs, 0);
+	init_completion(&handler_fired);
+
+	test_irq = lkl_get_free_irq("lkl_irq_kunit");
+	KUNIT_ASSERT_GE(test, test_irq, 0);
+
+	ret = request_irq(test_irq, test_irq_handler, 0,
+			  "lkl_irq_kunit", &test_irq);
+	KUNIT_ASSERT_EQ(test, ret, 0);
+
+	/*
+	 * Spawn a true host pthread — outside any kernel context. It
+	 * calls lkl_trigger_irq on the IRQ we just registered, exactly
+	 * the path a libusb event thread (or any host-side backend
+	 * notification thread) would take to inject a URB completion.
+	 *
+	 * wait_for_completion_timeout releases the LKL CPU so the host
+	 * pthread can acquire it via lkl_cpu_try_run_irq inside
+	 * lkl_trigger_irq.
+	 */
+	tid = lkl_ops->thread_create(host_thread_trigger, &test_irq);
+	KUNIT_ASSERT_NE(test, (unsigned long)tid, 0UL);
+
+	ret = wait_for_completion_timeout(&handler_fired,
+					  msecs_to_jiffies(500));
+	KUNIT_EXPECT_GT(test, ret, 0);
+	KUNIT_EXPECT_EQ(test, atomic_read(&handler_runs), 1);
+
+	lkl_ops->thread_join(tid);
+	free_irq(test_irq, &test_irq);
+	lkl_put_irq(test_irq, "lkl_irq_kunit");
+}
+
+static struct kunit_case lkl_irq_kunit_test_cases[] = {
+	KUNIT_CASE(host_thread_irq_delivery_test),
+	{}
+};
+
+static struct kunit_suite lkl_irq_kunit_test_suite = {
+	.name = "lkl_irq",
+	.test_cases = lkl_irq_kunit_test_cases,
+};
+
+kunit_test_suite(lkl_irq_kunit_test_suite);
+
+MODULE_LICENSE("GPL");

--- a/arch/lkl/kernel/threads.c
+++ b/arch/lkl/kernel/threads.c
@@ -4,6 +4,7 @@
 #include <linux/sched/signal.h>
 #include <asm/host_ops.h>
 #include <asm/cpu.h>
+#include <asm/irqflags.h>
 #include <asm/sched.h>
 #include <asm/switch_to.h>
 
@@ -16,6 +17,12 @@ static int init_ti(struct thread_info *ti)
 	ti->dead = false;
 	ti->prev_sched = NULL;
 	ti->tid = 0;
+	/*
+	 * New threads start with IRQs enabled. State moves with the
+	 * thread via _current_thread_info in __switch_to; see
+	 * arch/lkl/kernel/irq.c for the rationale.
+	 */
+	ti->irqs_enabled = ARCH_IRQ_ENABLED;
 
 	return 0;
 }

--- a/tools/lkl/Makefile.autoconf
+++ b/tools/lkl/Makefile.autoconf
@@ -252,6 +252,8 @@ define kunit_test_enable
   $(call set_autoconf_var,LKL_PCI_KUNIT_TEST,y)
   $(call set_kernel_config,KUNIT,y)
   $(call set_kernel_config,LKL_PCI_KUNIT_TEST,y)
+  $(call set_autoconf_var,LKL_IRQ_KUNIT_TEST,y)
+  $(call set_kernel_config,LKL_IRQ_KUNIT_TEST,y)
   $(if $(filter $(LD_FMT),$(KASAN_HOSTS)),$(call set_kernel_config,KASAN,y))
   $(if $(filter $(LD_FMT),$(KASAN_HOSTS)),$(call kasan_test_enable))
 endef

--- a/tools/lkl/tests/boot.c
+++ b/tools/lkl/tests/boot.c
@@ -706,6 +706,30 @@ static int lkl_test_kunit_pci(void)
 }
 #endif // LKL_HOST_CONFIG_LKL_PCI_KUNIT_TEST
 
+#ifdef LKL_HOST_CONFIG_LKL_IRQ_KUNIT_TEST
+static int lkl_test_kunit_irq(void)
+{
+	char *log = strdup(boot_log);
+	char *line = NULL;
+	int n;
+
+	line = strtok(log, "\n");
+	while (line) {
+		if (sscanf(line, "[ %*f] ok %d lkl_irq", &n) == 1) {
+			lkl_test_logf("%s", line);
+			free(log);
+			return TEST_SUCCESS;
+		}
+
+		line = strtok(NULL, "\n");
+	}
+
+	free(log);
+
+	return TEST_FAILURE;
+}
+#endif // LKL_HOST_CONFIG_LKL_IRQ_KUNIT_TEST
+
 #define CMD_LINE "mem=32M loglevel=8 "
 
 static int lkl_test_start_kernel(void)
@@ -778,6 +802,9 @@ struct lkl_test tests[] = {
 #endif
 #ifdef LKL_HOST_CONFIG_LKL_PCI_KUNIT_TEST
 	LKL_TEST(kunit_pci),
+#endif
+#ifdef LKL_HOST_CONFIG_LKL_IRQ_KUNIT_TEST
+	LKL_TEST(kunit_irq),
 #endif
 	LKL_TEST(stop_kernel),
 };


### PR DESCRIPTION
## Summary

`arch/lkl/kernel/irq.c` keeps `irqs_enabled` as a single `static bool`
global. That is fine for the in-tree test suite, which doesn't
exercise the failure paths it exposes, but it has two correctness
consequences for code that runs on LKL outside those tests:

1. **No per-thread isolation** of IRQ-enable state across context
   switches. Any kernel path that does `spin_lock_irqsave` and
   schedules before the matching restore leaks the DISABLED value to
   whichever thread runs next. (Sleeping with IRQs disabled is not a
   supported Linux pattern, and isn't the load-bearing motivation for
   this series — patch 1 is just the refactor that enables patch 2.)

2. **Host-thread callers of `lkl_trigger_irq` honour stale state.**
   `lkl_trigger_irq` is documented as callable "from arbitrary host
   threads," but reads `irqs_enabled` even when the caller is a host
   pthread that doesn't own the current `thread_info`. Host pthreads
   (libusb completion callbacks, glibc `SIGEV_THREAD` timer callbacks,
   anything created by a backend library that ends up posting an IRQ
   into the kernel from outside any kernel context) acquire the LKL
   CPU via `lkl_cpu_get` but never go through `__switch_to`, so
   `_current_thread_info` still points at whichever kernel task last
   ran, often the idle task. Honouring its stale `irqs_enabled`
   silently pends every host-injected IRQ. **This is the load-bearing
   bug, and patch 2 fixes it.**

### Context where this was hit

A research proof-of-concept that runs the mainline Linux `rtw88` USB
Wi-Fi driver entirely in userspace via LKL, on a real USB Wi-Fi
adapter. The host program links `liblkl.a`, registers a virtual USB
host controller into the in-process kernel (a ~470-line shim in the
`drivers/usb/host/`-style that translates `struct urb` to a flat view
struct and back), and forwards URBs to libusb running on the host
process. libusb's event thread is a true POSIX pthread; URB
completions are posted back into the LKL kernel from that thread via
`lkl_trigger_irq`, which is exactly the path bug 2 affects.

Behaviour with this series applied:

- On the master kernel, the `rtw88` driver hangs the in-process LKL
  kernel within ~50 USB control transfers, reliably. `jiffies` stops
  advancing; `msleep`-based kthreads freeze. `gdb` confirms the
  global `irqs_enabled` is stuck at 0.
- With this series, the same driver runs ~8000 control transfers,
  finishes firmware download, brings `wlan0` up, and the host can
  open an `AF_PACKET` socket on `wlan0` and capture 802.11 frames
  with radiotap headers. Validated on three RTL chips (RTL8812AU
  `0bda:8812`, RTL8821AU `2357:0120`, RTL8814AU `0bda:8813`). TX
  (radiotap injection via `AF_PACKET sendto` on `wlan0` in monitor
  mode) also works.

## What the series does

Three commits, in order:

1. **`lkl: make irqs_enabled per-thread via current_thread_info()`**
   — A pure refactor. Move `irqs_enabled` from a `static bool` global
   in `irq.c` into a field on `struct thread_info`; access via
   `current_thread_info()` from `arch_local_save_flags` /
   `arch_local_irq_restore` / `lkl_trigger_irq`. **No explicit
   save/restore code** — the existing
   `_current_thread_info = task_thread_info(next);` line in
   `__switch_to` is the entire mechanism. IRQ-enable state moves with
   its thread, the same way a real CPU's register file does. No
   behavioural change for the existing test suite.

2. **`lkl: deliver IRQs from host-thread callers regardless of
   irqs_enabled`** — The semantic fix. In `lkl_trigger_irq`, detect
   host-thread callers via
   `lkl_ops->thread_equal(ti->tid, lkl_ops->thread_self())` and
   deliver unconditionally; kernel-thread callers (including the
   recursive `lkl_trigger_irq -> IRQ -> softirq -> lkl_trigger_irq`
   path called out in the original comment) continue to honour their
   own per-thread `irqs_enabled`. Depends on patch 1 to give the
   owner-vs-self `tid` comparison something precise to compare.

3. **`lkl: add KUnit test for host-pthread caller of lkl_trigger_irq`**
   — Locks in the contract. New `CONFIG_LKL_IRQ_KUNIT_TEST` +
   `arch/lkl/kernel/irq_test.c`. The test spawns a true host pthread
   via `lkl_ops->thread_create`, has it call `lkl_trigger_irq` on a
   kernel-registered IRQ from outside any kernel context, and asserts
   the handler runs synchronously. Wired into the existing
   `kunit=yes` CI lane in `tools/lkl/Makefile.autoconf` alongside
   `LKL_PCI_KUNIT_TEST`, and into `tools/lkl/tests/boot.c` as
   `kunit_irq` (mirrors `kunit_pci` / `kunit_mmu`).

## Test plan

- [ ] CI `kunit` lane: the new `kunit_irq` test passes via the
  standard `ok N lkl_irq` line in the boot log (visible in the
  github-actions Test Results comment on this PR).
- [ ] CI `linux` / `windows-2022` / `clang-build` / `mmu_kasan`
  lanes: unchanged behaviour. The
  `current_thread_info()->irqs_enabled` field is initialised in
  `INIT_THREAD_INFO` and `init_ti`; pre-existing tests aren't
  affected.
- [ ] `checkpatch`: clean.
- [ ] End-to-end driver bring-up under the libusb-backed HCD shim
  described above: rtw88-family driver validated locally on the
  three RTL chips. All come up with this series applied; all hang
  on the un-patched kernel.

## Note on the previous version of this PR

An earlier revision of this series included a KUnit test that
provoked the cross-thread leak by doing `spin_lock_irqsave` +
`schedule_timeout` in one kthread while a sibling observed the IRQ
state — a pattern that is invalid in Linux generally. That framing
was misleading: the actual real-world bug is the host-pthread caller
path (bug 2 above), and the test now exercises that path directly,
via `lkl_ops->thread_create` and a registered IRQ handler. The
schedule-while-disabled framing is gone from both the test and the
commit messages.
