### PR TITLE
lkl: make object_is_on_stack() check host thread stacks

### DIFF
--- a/arch/lkl/include/asm/thread_info.h
+++ b/arch/lkl/include/asm/thread_info.h
@@ -8,6 +8,23 @@
 #include <asm/processor.h>
 #include <asm/host_ops.h>
 
+#define __HAVE_ARCH_OBJECT_IS_ON_STACK
+static inline int arch_object_is_on_stack(const void *obj)
+{
+	unsigned long addr = (unsigned long)obj;
+	unsigned long stack_size;
+	unsigned long stack;
+
+	if (!lkl_ops || !lkl_ops->thread_stack)
+		return 0;
+
+	stack = (unsigned long)lkl_ops->thread_stack(&stack_size);
+	if (!stack)
+		return 0;
+
+	return addr >= stack && addr - stack < stack_size;
+}
+
 struct thread_info {
 	struct task_struct *task;
 	unsigned long flags;

--- a/include/linux/sched/task_stack.h
+++ b/include/linux/sched/task_stack.h
@@ -88,10 +88,17 @@ void exit_task_stack_account(struct task_struct *tsk);
 
 static inline int object_is_on_stack(const void *obj)
 {
+#ifndef __HAVE_ARCH_OBJECT_IS_ON_STACK
 	void *stack = task_stack_page(current);
+#endif
 
 	obj = kasan_reset_tag(obj);
+
+#ifdef __HAVE_ARCH_OBJECT_IS_ON_STACK
+	return arch_object_is_on_stack(obj);
+#else
 	return (obj >= stack) && (obj < (stack + THREAD_SIZE));
+#endif
 }
 
 extern void thread_stack_cache_init(void);


### PR DESCRIPTION
blk_rq_map_kern() relies on object_is_on_stack() to route stack-allocated buffers to the bio_copy_kern() bounce path, since a buffer on the stack cannot be mapped directly into a bio.

object_is_on_stack() tests whether the buffer lies within [task_stack_page(current), task_stack_page(current) + THREAD_SIZE). On native architectures that range is the task's real execution stack, so the test works. Under LKL it does not: threads actually execute on host pthread stacks, and object_is_on_stack only checks whether it lies in init_thread_union.thread_info.stack. A buffer placed on the stack therefore lives on the host stack, outside the thread_info range, and object_is_on_stack() returns false. The bounce path is skipped and bio_map_kern() ends up calling virt_to_page() on a host-stack address that is not part of the kernel linear map, corrupting the I/O.

Add blk_kern_needs_copy() to detect this case by checking that both the start and the last byte of the buffer are virt_addr_valid(), and force the bio_copy_kern() bounce path when they are not. The check is guarded by CONFIG_LKL and compiles to false on other builds, so non-LKL kernels are unchanged.