### PR TITLE
mm: init hole_pfn from first memblock region instead of 0

### DIFF
--- a/mm/mm_init.c
+++ b/mm/mm_init.c
@@ -940,7 +940,7 @@ static void __init memmap_init_zone_range(struct zone *zone,
 static void __init memmap_init(void)
 {
 	unsigned long start_pfn, end_pfn;
-	unsigned long hole_pfn = 0;
+	unsigned long hole_pfn = ARCH_PFN_OFFSET;
 	int i, j, zone_id = 0, nid;
 
 	for_each_mem_pfn_range(i, MAX_NUMNODES, &start_pfn, &end_pfn, &nid) {


### PR DESCRIPTION
memmap_init() initializes hole_pfn to 0. On LKL with MMU, the first memblock memory range starts at ARCH_PFN_OFFSET, and PFNs below that offset have no corresponding struct pages in the FLATMEM memory map.

As a result, memmap_init_zone_range() calls init_unavailable_range() for [0, start_pfn). This is currently harmless because the pageblock validity check skips these PFNs before pfn_to_page() is called, but it unnecessarily scans all pageblocks below ARCH_PFN_OFFSET.

Initialize hole_pfn from the first memblock memory range so that the scan starts at the first PFN represented by the memory map.